### PR TITLE
Add unit test configuration with H2 and set test profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ out/
 src/main/resources/data.sql
 
 tmp
+
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -66,4 +66,7 @@ spotless {
 }
 tasks.named('test') {
 	useJUnitPlatform()
+
+	// Set the active profile for unit tests
+	systemProperty 'spring.profiles.active', 'unit-test'
 }

--- a/src/test/resources/application-unit-test.properties
+++ b/src/test/resources/application-unit-test.properties
@@ -1,0 +1,26 @@
+# Unit Test Environment Configuration - using H2 in-memory database
+
+# Database settings
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.driver-class-name=org.h2.Driver
+
+# JPA/Hibernate settings
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+spring.jpa.show-sql=true
+
+# Schema & Data initialization - disabled for unit tests
+spring.sql.init.mode=never
+
+# Disable open in view for tests
+spring.jpa.open-in-view=false
+
+# Logging settings for tests
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql=TRACE
+logging.level.com.example.achievement_tracker=DEBUG
+
+# Disable web resources and thymeleaf cache for tests
+spring.thymeleaf.cache=false


### PR DESCRIPTION
Introduced a dedicated `application-unit-test.properties` file to configure the unit testing environment using an H2 in-memory database, with no data seeding. Updated the test task in `build.gradle` to activate the `unit-test` profile. Adjusted `.gitignore` to exclude `.env`.